### PR TITLE
Add FuseSoC support and Github CI actions

### DIFF
--- a/.github/workflows/fusesoc.yml
+++ b/.github/workflows/fusesoc.yml
@@ -1,0 +1,33 @@
+name: run-fusesoc-targets
+on: [push]
+
+jobs:
+  build-openlane-sky130:
+    runs-on: ubuntu-latest
+    env:
+      REPO : verilog-dsp
+      VLNV : verilog-dsp
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: verilog-dsp
+      - run: echo "EDALIZE_LAUNCHER=el_docker" >> $GITHUB_ENV
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=sky130_cic_decimator $VLNV
+
+  lint-verilator-cic-decimator:
+    runs-on: ubuntu-latest
+    env:
+      REPO : verilog-dsp
+      VLNV : verilog-dsp
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: verilog-dsp
+      - run: sudo apt install verilator
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=lint_cic_decimator $VLNV

--- a/cic_decimator.core
+++ b/cic_decimator.core
@@ -1,0 +1,29 @@
+CAPI=2:
+
+name : ::verilog-dsp:0
+
+filesets:
+  rtl:
+    files:
+      - rtl/cic_decimator.v : {file_type : verilogSource}
+
+  sky130:
+    files: [data/sky130.tcl : {file_type : tclSource}]
+
+targets:
+  default:
+    filesets : [rtl]
+
+  lint_cic_decimator:
+    default_tool: verilator
+    filesets : [rtl]
+    tools:
+      verilator:
+        mode: lint-only
+    toplevel : cic_decimator
+
+  sky130_cic_decimator:
+    default_tool : openlane
+    filesets : [rtl, sky130]
+    toplevel : cic_decimator
+    

--- a/data/sky130.tcl
+++ b/data/sky130.tcl
@@ -1,0 +1,3 @@
+set ::env(CLOCK_PERIOD) "10.000"
+set ::env(CLOCK_PORT) "clk"
+set ::env(CLOCK_NET) $::env(CLOCK_PORT)

--- a/rtl/cic_decimator.v
+++ b/rtl/cic_decimator.v
@@ -95,6 +95,9 @@ assign output_tvalid = input_tvalid & cycle_reg == 0;
 
 genvar k;
 integer i;
+integer j;
+integer l;
+integer v;
 
 initial begin
     for (i = 0; i < N; i = i + 1) begin
@@ -131,15 +134,15 @@ for (k = 0; k < N; k = k + 1) begin : comb
     reg [REG_WIDTH-1:0] delay_reg[M-1:0];
 
     initial begin
-        for (i = 0; i < M; i = i + 1) begin
-            delay_reg[i] <= 0;
+        for (j = 0; j < M; j = j + 1) begin
+            delay_reg[j] <= 0;
         end
     end
 
     always @(posedge clk) begin
         if (rst) begin
-            for (i = 0; i < M; i = i + 1) begin
-                delay_reg[i] <= 0;
+            for (l = 0; l < M; l = l + 1) begin
+                delay_reg[l] <= 0;
             end
             comb_reg[k] <= 0;
         end else begin
@@ -152,7 +155,7 @@ for (k = 0; k < N; k = k + 1) begin : comb
                     comb_reg[k] <= $signed(comb_reg[k-1]) - $signed(delay_reg[M-1]);
                 end
 
-                for (i = 0; i < M-1; i = i + 1) begin
+                for (v = 0; v < M-1; v = v + 1) begin
                     delay_reg[i+1] <= delay_reg[i];
                 end
             end


### PR DESCRIPTION
This adds a core description file for the verilog-dsp core that exposes targets
for linting and for building a GDSII using OpenLANE. All targets are also
implemented as Github actions so that they get run on every push to the repo.

Quick FuseSoC instructions:

 #install FuseSoC
pip3 install fusesoc
 #Create and enter a new workspace
mkdir workspace && cd workspace
 #Register verilog-dsp as a library in the workspace
fusesoc library add verilog-dsp /path/to/verilog-dsp
 #...if repo is available locally or...
fusesoc library add verilog-dsp https://github.com/alexforencich/verilog-dsp
 #...to get the upstream repo

 #To run lint
fusesoc run --target=lint_cic_decimator verilog-dsp
 #To build with OpenLANE running in a docker container
EDALIZE_LAUNCHER=el_docker fusesoc run --target=sky130_cic_decimator verilog-dsp
 #List all targets
fusesoc core show verilog-dsp

Note that only cic_decimator is covered as of now